### PR TITLE
fixed edge cases when web service returns unexpected name and address format

### DIFF
--- a/src/Snowcap/Vat/Validation.php
+++ b/src/Snowcap/Vat/Validation.php
@@ -67,8 +67,8 @@ class Validation
 
         if ($rs->valid) {
             $this->_valid = true;
-            list($denomination, $name) = explode(" ", $rs->name, 2);
-            list($streetline, $cityline) = explode("\n", $rs->address);
+            list($denomination, $name) = strpos($rs->name, ' ') !== false ? explode(" ", $rs->name, 2) : array('', '');
+            list($streetline, $cityline) = strpos($rs->address, "\n" !== false) ? explode("\n", $rs->address) : array('', '');
             preg_match('/(.+) ([^ ]*[0-9]+[^ ]*)/', $this->cleanUpString($streetline), $parts);
             if (count($parts) === 0) {
                 $street = $this->cleanUpString($streetline);
@@ -78,7 +78,7 @@ class Validation
                 $number = $parts[2];
             }
 
-            list($zip, $city) = explode(' ', $this->cleanUpString($cityline), 2);
+            list($zip, $city) = $cityline !== '' ? explode(' ', $this->cleanUpString($cityline), 2) : array('', '');
 
             $this->_data = array(
                 'denomination' => $denomination,


### PR DESCRIPTION
on validating VAT number ES00159660V, here is the raw output from the webservice:

```
stdClass Object
(
    [countryCode] => ES
    [vatNumber] => 00159660V
    [requestDate] => 2014-05-29+02:00
    [valid] => 1
    [name] => ---
    [address] => ---
)
```

We can see that this VAT number is valid, but the name and address format are unexpected by the check function, resulting in the following PHP notices:

```
Notice: Undefined offset: 1 in /Users/yann/www-dev/vat-validation/src/Snowcap/Vat/Validation.php on line 70
Notice: Undefined offset: 1 in /Users/yann/www-dev/vat-validation/src/Snowcap/Vat/Validation.php on line 71
Notice: Undefined offset: 1 in /Users/yann/www-dev/vat-validation/src/Snowcap/Vat/Validation.php on line 81
```

I added checks before assigning $denomination, $name, $streetline, $cityline, $zip and $city vars.
